### PR TITLE
CE-373: change ssl certificate

### DIFF
--- a/terraform/firebreak-q1-event-normalisation/variables.tf
+++ b/terraform/firebreak-q1-event-normalisation/variables.tf
@@ -36,7 +36,7 @@ variable "alb_access_logs" {
 
 variable "alb_certificate_arn" {
   description = "ALB Certificate ARN address"
-  default     = "arn:aws:acm:eu-west-2:489877524855:certificate/5119be97-6e63-4c45-9a7a-a7db360f4921"
+  default     = "arn:aws:acm:eu-west-2:489877524855:certificate/e0735739-9295-4170-aa1d-957ad499da3e"
   type        = "string"
 }
 


### PR DESCRIPTION
The team-manual site that runs on this lambda has a new DNS name:
cyber-security-team-manual.cyber-security-repo.info
therefore it requires a new ssl certificate.
This pts the new certificate arn in place so terraform will lay it down
for use.

@ronocg <conor.glynn@digital.cabinet-office.gov.uk>